### PR TITLE
Support async Ring

### DIFF
--- a/test/ring/middleware/gzip_test.clj
+++ b/test/ring/middleware/gzip_test.clj
@@ -35,6 +35,18 @@
     (is (= "gzip" (encoding resp)))
     (is (Arrays/equals (unzip (resp :body)) (.getBytes output)))))
 
+(deftest test-basic-gzip-async
+  "middleware should work with 3-arg async handlers as well"
+  (let [app (wrap-gzip
+             (fn [request respond raise]
+               (respond {:status 200
+                         :body output
+                         :headers {}})))
+        resp (app (accepting "gzip") identity identity)]
+    (is (= 200 (:status resp)))
+    (is (= "gzip" (encoding resp)))
+    (is (Arrays/equals (unzip (resp :body)) (.getBytes output)))))
+
 (deftest test-inputstream-gzip
   (let [app (wrap-gzip (fn [req] {:status 200
                                   :body (StringBufferInputStream. output)
@@ -57,7 +69,7 @@
         (println "Running on JDK7+, testing gzipping of seq response bodies.")
         (is (= "gzip" (encoding resp)))
         (is (Arrays/equals (unzip (resp :body)) (.getBytes output))))
-      (do 
+      (do
         (println "Running on <=JDK6, testing non-gzipping of seq response bodies.")
         (is (nil? (encoding resp)))
         (is (= seq-body (resp :body)))))))


### PR DESCRIPTION
Minor tweaks to the middleware so it will can be used with either a 3-airty async handler ([added in Ring 1.6.0](https://github.com/ring-clojure/ring/blob/900aaffb364dc97d25d91e97abd508b8dc3255cb/CHANGELOG.md#160-beta2-2016-07-07)) or with a 1-arity synchronous handler.