### PR TITLE
Exposing functions publicly

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,12 +2,14 @@
   :url "https://github.com/clj-commons/ring-gzip-middleware"
   :description "Ring gzip encoding middleware"
   :dependencies [[org.clojure/clojure "1.9.0"]]
-  :profiles {:1.10 {:dependencies [[org.clojure/clojure "1.10.0-RC3"]]}
+  :profiles {:1.12 {:dependencies [[org.clojure/clojure "1.12.0"]]}
+             :1.11 {:dependencies [[org.clojure/clojure "1.11.4"]]}
+             :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]]}
              :1.9  {}
              :1.8  {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.7  {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.6  {:dependencies [[org.clojure/clojure "1.6.0"]]}}
   :deploy-repositories [["releases" :clojars]
                         ["snapshots" :clojars]]
-  :aliases {"all" ["with-profile" "1.6:1.7:1.8:1.9:1.10"]}
+  :aliases {"all" ["with-profile" "1.6:1.7:1.8:1.9:1.10:1.11:1.12"]}
   :min-lein-version "2.0.0")

--- a/test/ring/middleware/gzip_test.clj
+++ b/test/ring/middleware/gzip_test.clj
@@ -29,6 +29,12 @@
 (defn accepting [ctype]
   {:headers {"accept-encoding" ctype}})
 
+(defn set-encoding
+  ([resp] (set-encoding resp false))
+  ([resp caps?]
+   (let [content-encoding (if caps? "Content-Encoding" "content-encoding")]
+     (assoc-in resp [:headers content-encoding] "text"))))
+
 (deftest test-basic-gzip
   (let [resp (app (accepting "gzip"))]
     (is (= 200 (:status resp)))
@@ -36,16 +42,16 @@
     (is (Arrays/equals (unzip (resp :body)) (.getBytes output)))))
 
 (deftest test-basic-gzip-async
-  "middleware should work with 3-arg async handlers as well"
-  (let [app (wrap-gzip
-             (fn [request respond raise]
-               (respond {:status 200
-                         :body output
-                         :headers {}})))
-        resp (app (accepting "gzip") identity identity)]
-    (is (= 200 (:status resp)))
-    (is (= "gzip" (encoding resp)))
-    (is (Arrays/equals (unzip (resp :body)) (.getBytes output)))))
+  (testing "middleware should work with 3-arg async handlers as well"
+    (let [app (wrap-gzip
+               (fn [request respond raise]
+                 (respond {:status 200
+                           :body output
+                           :headers {}})))
+          resp (app (accepting "gzip") identity identity)]
+      (is (= 200 (:status resp)))
+      (is (= "gzip" (encoding resp)))
+      (is (Arrays/equals (unzip (resp :body)) (.getBytes output))))))
 
 (deftest test-inputstream-gzip
   (let [app (wrap-gzip (fn [req] {:status 200
@@ -75,40 +81,67 @@
         (is (= seq-body (resp :body)))))))
 
 (deftest test-accepts
-  (doseq [ctype ["gzip" "*" "gzip,deflate" "gzip,deflate,sdch"
-                 "gzip, deflate" "gzip;q=1" "deflate,gzip"
-                 "deflate,gzip,sdch" "deflate,gzip;q=1"
-                 "deflate,gzip;q=1,sdch"
-                 "gzip;q=0.5"]]
-    (is (= "gzip" (encoding (app (accepting ctype))))))
-  (doseq [ctype ["" "gzip;q=0" "deflate" "deflate,sdch"
-                 "deflate,gzip;q=0" "deflate,gzip;q=0,sdch"
-                 "gzip;q=0,deflate" "*;q=0"]]
-    (is (nil? (encoding (app (accepting ctype)))))))
+  (testing "appropriate requests will be zipped"
+    (doseq [ctype ["gzip" "*" "gzip,deflate" "gzip,deflate,sdch"
+                   "gzip, deflate" "gzip;q=1" "deflate,gzip"
+                   "deflate,gzip,sdch" "deflate,gzip;q=1"
+                   "deflate,gzip;q=1,sdch"
+                   "gzip;q=0.5"]]
+      (is (= "gzip" (encoding (app (accepting ctype)))))
+      (is (accepts-gzip? (accepting ctype)))))
+  (testing "requests that ask for a zip, but not the supported type of zip are not zipped"
+    (doseq [ctype ["" "gzip;q=0" "deflate" "deflate,sdch"
+                   "deflate,gzip;q=0" "deflate,gzip;q=0,sdch"
+                   "gzip;q=0,deflate" "*;q=0"]]
+      (is (nil? (encoding (app (accepting ctype))))))))
 
 (deftest test-min-length
-  "don't compress string bodies less than 200 characters long"
-  (let [output (apply str (repeat 10 "a"))
-        app (wrap-gzip (fn [req] {:status 200
-                                  :body output
-                                  :headers {}}))
-        resp (app (accepting "gzip"))]
-    (is (nil? (encoding (app (accepting "gzip")))))))
+  (testing "Compress string bodies greater than the min-length (200) characters long"
+    (let [output (apply str (repeat (inc min-length) "a"))
+          resp {:status 200
+                :body output
+                :headers {}}
+          app (wrap-gzip (fn [req] resp))]
+      (is (= "gzip" (encoding (app (accepting "gzip")))))
+      (is (supported-response? resp))
+      (testing ", but not string bodies at or below min-length"
+        (let [resp (update resp :body subs 1)
+              app (wrap-gzip (fn [req] resp))]
+          (is (nil? (encoding (app (accepting "gzip")))))
+          (is (not (supported-response? resp))))))))
 
 (deftest test-wrapped-encoding
-  "don't compress responses which already have a content-encoding header"
-  (let [app (wrap-gzip (fn [req] {:status 200
-                                  :body output
-                                  :headers {"Content-Encoding" "text"}}))
-        resp (app (accepting "gzip"))]
-    (is (= "text" (encoding resp)))
-    (is (= output (:body resp)))))
+  (testing "don't compress responses which already have a content-encoding header"
+    (let [response {:status 200
+                    :body output
+                    :headers {"Content-Encoding" "text"}}
+          app (wrap-gzip (fn [req] response))
+          resp (app (accepting "gzip"))]
+      (is (= "text" (encoding resp)))
+      (is (= output (:body resp))))))
+
+(deftest test-supported
+  (testing "responses that already have an encoding cannot be zipped"
+    (doseq [ctype ["gzip" "*" "gzip,deflate" "gzip,deflate,sdch"
+                   "gzip, deflate" "gzip;q=1" "deflate,gzip"
+                   "deflate,gzip,sdch" "deflate,gzip;q=1"
+                   "deflate,gzip;q=1,sdch"
+                   "gzip;q=0.5" "" "gzip;q=0" "deflate" "deflate,sdch"
+                   "deflate,gzip;q=0" "deflate,gzip;q=0,sdch"
+                   "gzip;q=0,deflate" "*;q=0"]]
+      (is (not (supported-response? (set-encoding (accepting ctype)))))
+      (is (not (supported-response? (set-encoding (accepting ctype) true)))))))
 
 (deftest test-status
-  "don't compress non-2xx responses"
-  (let [app (wrap-gzip (fn [req] {:status 404
-                                  :body output
-                                  :headers {}}))
-        resp (app (accepting "gzip"))]
-    (is (nil? (encoding resp)))
-    (is (= output (:body resp)))))
+  (testing "don't compress non-2xx responses"
+    (let [app (wrap-gzip (fn [req] {:status 404
+                                    :body output
+                                    :headers {}}))
+          resp (app (accepting "gzip"))]
+      (is (nil? (encoding resp)))
+      (is (= output (:body resp))))))
+
+(deftest test-setting-headers
+  (testing "updating the headers of a response to indicate that they have been gziped"
+    (is (= {"Content-Encoding" "gzip"} (set-response-headers {"Content-Length" 201})))
+    (is (= {"Content-Encoding" "gzip" "Age" 24} (set-response-headers {"Age" 24})))))

--- a/test/ring/middleware/gzip_test.clj
+++ b/test/ring/middleware/gzip_test.clj
@@ -105,7 +105,7 @@
     (is (= output (:body resp)))))
 
 (deftest test-status
-  "don't compress non-200 responses"
+  "don't compress non-2xx responses"
   (let [app (wrap-gzip (fn [req] {:status 404
                                   :body output
                                   :headers {}}))


### PR DESCRIPTION
When systems like Liberator ask for a streamed response, the process gets handled outside of the middleware stack. This PR break up the internal operations to be more composable and exposes them for use outside of the middleware stack.

Most of the composability is guided by [ring-gzip](https://github.com/bertrandk/ring-gzip) from @bertrandk, though I have not included other features that are not relevant to the purpose of this PR (e.g. "Vary" headers)